### PR TITLE
Remove division

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ Arduino sketch to operate new PSA comfort devices (CAN2010) on old BSI CAN-BUS (
 
 ### Real life examples
 > ![NAC on RCZ](https://i.imgur.com/Nb3CrUN.jpg)
-  NAC (Connected NAV) on RCZ (T75)
+  NAC (Connected NAV) on Peugeot RCZ (2012)
 > ![COLOR MATRIX on RCZ](https://i.imgur.com/7zP7qf6.jpg)
-  Color 2010 Matrix on RCZ (T75) from Peugeot 2008 (2019)
+  Color 2010 Matrix from Peugeot 2008 (2019) on Peugeot RCZ (2012)
 > ![NAC on C4](https://i.imgur.com/Fjc8PhI.jpg)
-  NAC (Connected NAV) on C4 first model (2004)
+  NAC (Connected NAV) on Citroen C4 first model (2004)
+> ![NAC on 207](https://i.imgur.com/rdJuei6.jpg)
+  NAC (Connected NAV) on Peugeot 207 (2010)


### PR DESCRIPTION
Replace division with shift, fix erros in maintance period
Replaced:
integer division by 2:  with right shift by 1
integer division by 4:  with right shift by 2
Fixed maintance period debug print:
period is coded in CAN messages with WORD data type